### PR TITLE
Feat/#1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/filb/application/JwtService.java
+++ b/src/main/java/com/backend/filb/application/JwtService.java
@@ -16,9 +16,9 @@ import java.util.Date;
 public class JwtService {
     private SecretKey key = Jwts.SIG.HS256.key().build();
 
-    public String createJWT(Long id) {
+    public String createJWT(String email) {
         return Jwts.builder()
-                .claim("id", id)
+                .claim("email", email)
                 .signWith(key)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + 60 * 10000))

--- a/src/main/java/com/backend/filb/application/JwtService.java
+++ b/src/main/java/com/backend/filb/application/JwtService.java
@@ -41,7 +41,7 @@ public class JwtService {
 
     public String getMemberId() {
         String accessToken = getJWT();
-        System.out.println(accessToken);
+
         if (accessToken == null) {
             throw new JwtException("토큰이 유효하지 않습니다.");
         }

--- a/src/main/java/com/backend/filb/application/JwtService.java
+++ b/src/main/java/com/backend/filb/application/JwtService.java
@@ -39,15 +39,18 @@ public class JwtService {
         return token.replace("Bearer ", "");
     }
 
-    public String getMemberId() {
-        String accessToken = getJWT();
-
+    public void checkTokenValidation(String accessToken){
         if (accessToken == null) {
             throw new JwtException("토큰이 유효하지 않습니다.");
         }
         if (accessToken.isEmpty()) {
             throw new JwtException("토큰이 유효하지 않습니다.");
         }
+    }
+
+    public String getMemberId() {
+        String accessToken = getJWT();
+        checkTokenValidation(accessToken);
         Jws<Claims> jws;
 
         try {

--- a/src/main/java/com/backend/filb/application/JwtService.java
+++ b/src/main/java/com/backend/filb/application/JwtService.java
@@ -1,0 +1,61 @@
+package com.backend.filb.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Service
+public class JwtService {
+    private SecretKey key = Jwts.SIG.HS256.key().build();
+
+    public String createJWT(Long id) {
+        return Jwts.builder()
+                .claim("id", id)
+                .signWith(key)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 60 * 10000))
+                .compact();
+    }
+
+    public String getJWT() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+        String token = request.getHeader("Authorization");
+
+        System.out.println("token = " + token);
+
+        return token.replace("Bearer ", "");
+    }
+
+    public String getMemberId() {
+        String accessToken = getJWT();
+        System.out.println(accessToken);
+        if (accessToken == null) {
+            throw new JwtException("토큰이 유효하지 않습니다.");
+        }
+        if (accessToken.isEmpty()) {
+            throw new JwtException("토큰이 유효하지 않습니다.");
+        }
+        Jws<Claims> jws;
+
+        try {
+            jws = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(accessToken);
+        } catch (JwtException e) {
+            throw new RuntimeException(e);
+        }
+
+        return jws.getPayload()
+                .get("id", String.class);
+    }
+}

--- a/src/main/java/com/backend/filb/application/JwtService.java
+++ b/src/main/java/com/backend/filb/application/JwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -16,12 +17,15 @@ import java.util.Date;
 public class JwtService {
     private SecretKey key = Jwts.SIG.HS256.key().build();
 
+    @Value("${token.expiration}")
+    private int tokenExpiration;
+
     public String createJWT(String email) {
         return Jwts.builder()
                 .claim("email", email)
                 .signWith(key)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 60 * 10000))
+                .setExpiration(new Date(System.currentTimeMillis() + tokenExpiration))
                 .compact();
     }
 

--- a/src/main/java/com/backend/filb/application/MemberService.java
+++ b/src/main/java/com/backend/filb/application/MemberService.java
@@ -1,6 +1,5 @@
 package com.backend.filb.application;
 
-
 import com.backend.filb.domain.entity.Member;
 import com.backend.filb.domain.repository.MemberRepository;
 import com.backend.filb.dto.MemberRequest;
@@ -12,9 +11,11 @@ import java.util.NoSuchElementException;
 public class MemberService {
 
     private MemberRepository memberRepository;
+    private JwtService jwtService;
 
-    public MemberService(MemberRepository memberRepository){
+    public MemberService(MemberRepository memberRepository,JwtService jwtService){
         this.memberRepository = memberRepository;
+        this.jwtService = jwtService;
     }
 
     public Member join(MemberRequest memberRequest) {
@@ -23,6 +24,16 @@ public class MemberService {
             memberRepository.save(member);
         }
         throw new NoSuchElementException("이미 존재하는 회원입니다.");
+    }
+
+    public String login(MemberRequest memberRequest) {
+        Member dbMember = memberRepository.findById(memberRequest.memberId())
+                .orElseThrow(() -> new NoSuchElementException("로그인에 실패했습니다 다시 시도해주세요"));
+        if (!memberRequest.password().equals(dbMember.getPassword())) {
+            throw new NoSuchElementException("로그인에 실패하였습니다. 다시 시도해주세요");
+        } else {
+            return jwtService.createJWT(memberRequest.memberId());
+        }
     }
 
     private Member MapMemberRequestToMember(MemberRequest memberRequest){

--- a/src/main/java/com/backend/filb/application/MemberService.java
+++ b/src/main/java/com/backend/filb/application/MemberService.java
@@ -20,10 +20,9 @@ public class MemberService {
 
     public Member join(MemberRequest memberRequest) {
         Member member = MapMemberRequestToMember(memberRequest);
-        if (!memberRepository.existsByEmail(memberRequest.email())) {
-            return memberRepository.save(member);
-        }
-        throw new NoSuchElementException("이미 존재하는 회원입니다.");
+        memberRepository.findByEmail(memberRequest.email())
+                .orElseThrow(() -> new NoSuchElementException("이미 존재하는 회원입니다."));
+        return memberRepository.save(member);
     }
 
     public String login(MemberRequest memberRequest) {

--- a/src/main/java/com/backend/filb/application/MemberService.java
+++ b/src/main/java/com/backend/filb/application/MemberService.java
@@ -1,0 +1,4 @@
+package com.backend.filb.application;
+
+public class MemberService {
+}

--- a/src/main/java/com/backend/filb/application/MemberService.java
+++ b/src/main/java/com/backend/filb/application/MemberService.java
@@ -13,30 +13,30 @@ public class MemberService {
     private MemberRepository memberRepository;
     private JwtService jwtService;
 
-    public MemberService(MemberRepository memberRepository,JwtService jwtService){
+    public MemberService(MemberRepository memberRepository, JwtService jwtService) {
         this.memberRepository = memberRepository;
         this.jwtService = jwtService;
     }
 
     public Member join(MemberRequest memberRequest) {
         Member member = MapMemberRequestToMember(memberRequest);
-        if (!memberRepository.existsById(memberRequest.memberId())) {
-            memberRepository.save(member);
+        if (!memberRepository.existsByEmail(memberRequest.email())) {
+            return memberRepository.save(member);
         }
         throw new NoSuchElementException("이미 존재하는 회원입니다.");
     }
 
     public String login(MemberRequest memberRequest) {
-        Member dbMember = memberRepository.findById(memberRequest.memberId())
+        Member dbMember = memberRepository.findByEmail(memberRequest.email())
                 .orElseThrow(() -> new NoSuchElementException("로그인에 실패했습니다 다시 시도해주세요"));
         if (!memberRequest.password().equals(dbMember.getPassword())) {
             throw new NoSuchElementException("로그인에 실패하였습니다. 다시 시도해주세요");
         } else {
-            return jwtService.createJWT(memberRequest.memberId());
+            return jwtService.createJWT(memberRequest.email());
         }
     }
 
-    private Member MapMemberRequestToMember(MemberRequest memberRequest){
-        return new Member(memberRequest.memberId(),memberRequest.email(),memberRequest.password(),memberRequest.name());
+    private Member MapMemberRequestToMember(MemberRequest memberRequest) {
+        return new Member(null, memberRequest.email(), memberRequest.password(), memberRequest.name());
     }
 }

--- a/src/main/java/com/backend/filb/application/MemberService.java
+++ b/src/main/java/com/backend/filb/application/MemberService.java
@@ -1,4 +1,31 @@
 package com.backend.filb.application;
 
+
+import com.backend.filb.domain.entity.Member;
+import com.backend.filb.domain.repository.MemberRepository;
+import com.backend.filb.dto.MemberRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
 public class MemberService {
+
+    private MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository){
+        this.memberRepository = memberRepository;
+    }
+
+    public Member join(MemberRequest memberRequest) {
+        Member member = MapMemberRequestToMember(memberRequest);
+        if (!memberRepository.existsById(memberRequest.memberId())) {
+            memberRepository.save(member);
+        }
+        throw new NoSuchElementException("이미 존재하는 회원입니다.");
+    }
+
+    private Member MapMemberRequestToMember(MemberRequest memberRequest){
+        return new Member(memberRequest.memberId(),memberRequest.email(),memberRequest.password(),memberRequest.name());
+    }
 }

--- a/src/main/java/com/backend/filb/application/ReportService.java
+++ b/src/main/java/com/backend/filb/application/ReportService.java
@@ -1,0 +1,7 @@
+package com.backend.filb.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportService {
+}

--- a/src/main/java/com/backend/filb/domain/entity/Emotions.java
+++ b/src/main/java/com/backend/filb/domain/entity/Emotions.java
@@ -1,0 +1,13 @@
+package com.backend.filb.domain.entity;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Emotions {
+    private Integer happiness;
+    private Integer discomfort;
+    private Integer fear;
+    private Integer surprise;
+    private Integer anger;
+    private Integer sadness;
+}

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -24,4 +24,7 @@ public class Member {
         this.name = name;
     }
 
+    public String getPassword() {
+        return password;
+    }
 }

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -25,7 +25,6 @@ public class Member {
     }
 
     public Member() {
-
     }
 
     public String getPassword() {

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -16,4 +16,12 @@ public class Member {
 
     @Column(nullable = false)
     private String name;
+
+    public Member(Long memberId, String email, String password, String name) {
+        this.memberId = memberId;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+
 }

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -1,4 +1,19 @@
 package com.backend.filb.domain.entity;
 
+import jakarta.persistence.*;
+
+@Entity
 public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
 }

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -24,6 +24,10 @@ public class Member {
         this.name = name;
     }
 
+    public Member() {
+
+    }
+
     public String getPassword() {
         return password;
     }

--- a/src/main/java/com/backend/filb/domain/entity/Member.java
+++ b/src/main/java/com/backend/filb/domain/entity/Member.java
@@ -1,0 +1,4 @@
+package com.backend.filb.domain.entity;
+
+public class Member {
+}

--- a/src/main/java/com/backend/filb/domain/entity/Report.java
+++ b/src/main/java/com/backend/filb/domain/entity/Report.java
@@ -1,0 +1,21 @@
+package com.backend.filb.domain.entity;
+
+import jakarta.persistence.*;
+
+import java.util.Date;
+
+@Entity
+public class Report {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long reportId;
+    private Date date;
+    private String diary;
+    private Integer totalEmotion;
+    private String Feedback;
+    @Embedded
+    private Emotions emotions;
+    private Integer negativeSentencePercent;
+    private Integer positiveSentencePercent;
+    private Integer totalSentenceCount;
+}

--- a/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
+++ b/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package com.backend.filb.domain.repository;
+
+public class MemberRepository {
+}

--- a/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
+++ b/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
@@ -3,5 +3,10 @@ package com.backend.filb.domain.repository;
 import com.backend.filb.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member,Long> {
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
+++ b/src/main/java/com/backend/filb/domain/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package com.backend.filb.domain.repository;
 
-public class MemberRepository {
+import com.backend.filb.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
 }

--- a/src/main/java/com/backend/filb/domain/repository/ReportRepository.java
+++ b/src/main/java/com/backend/filb/domain/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package com.backend.filb.domain.repository;
+
+import com.backend.filb.domain.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report,Long> {
+}

--- a/src/main/java/com/backend/filb/dto/MemberRequest.java
+++ b/src/main/java/com/backend/filb/dto/MemberRequest.java
@@ -1,0 +1,4 @@
+package com.backend.filb.dto;
+
+public record MemberRequest() {
+}

--- a/src/main/java/com/backend/filb/dto/MemberRequest.java
+++ b/src/main/java/com/backend/filb/dto/MemberRequest.java
@@ -1,4 +1,9 @@
 package com.backend.filb.dto;
 
-public record MemberRequest() {
+public record MemberRequest(
+        Long memberId,
+        String email,
+        String password,
+        String name
+) {
 }

--- a/src/main/java/com/backend/filb/dto/MemberRequest.java
+++ b/src/main/java/com/backend/filb/dto/MemberRequest.java
@@ -1,7 +1,6 @@
 package com.backend.filb.dto;
 
 public record MemberRequest(
-        Long memberId,
         String email,
         String password,
         String name

--- a/src/main/java/com/backend/filb/dto/MemberResponse.java
+++ b/src/main/java/com/backend/filb/dto/MemberResponse.java
@@ -1,0 +1,4 @@
+package com.backend.filb.dto;
+
+public record MemberResponse() {
+}

--- a/src/main/java/com/backend/filb/dto/ReportRequest.java
+++ b/src/main/java/com/backend/filb/dto/ReportRequest.java
@@ -1,0 +1,16 @@
+package com.backend.filb.dto;
+
+import com.backend.filb.domain.entity.Emotions;
+import jakarta.persistence.Embedded;
+
+public record ReportRequest(
+         Long reportId,
+         Integer totalEmotion,
+         String Feedback,
+        @Embedded
+         Emotions emotions,
+         Integer negativeSentencePercent,
+         Integer positiveSentencePercent,
+         Integer totalSentenceCount
+) {
+}

--- a/src/main/java/com/backend/filb/presentation/MemberController.java
+++ b/src/main/java/com/backend/filb/presentation/MemberController.java
@@ -1,4 +1,25 @@
 package com.backend.filb.presentation;
 
+import com.backend.filb.application.MemberService;
+import com.backend.filb.domain.entity.Member;
+import com.backend.filb.dto.MemberRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
 public class MemberController {
+    private MemberService memberService;
+
+    public MemberController(MemberService memberService){
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<Member> join(
+            @RequestBody MemberRequest memberRequest
+    ) {
+        Member member = memberService.join(memberRequest);
+        return ResponseEntity.ok().body(member);
+    }
 }

--- a/src/main/java/com/backend/filb/presentation/MemberController.java
+++ b/src/main/java/com/backend/filb/presentation/MemberController.java
@@ -19,11 +19,13 @@ public class MemberController {
     }
 
     @PostMapping("/join")
-    public ResponseEntity<String> join(
+    public ResponseEntity join(
             @RequestBody MemberRequest memberRequest
     ) {
         memberService.join(memberRequest);
-        return ResponseEntity.ok().body("회원가입에 성공하셨습니다.");
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Message", "회원가입에 성공하셨습니다.");
+        return ResponseEntity.ok().headers(headers).body(null);
     }
 
     @PostMapping("/login")
@@ -33,7 +35,8 @@ public class MemberController {
         String jwt = memberService.login(memberRequest);
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", jwt);
-        return ResponseEntity.ok().headers(headers).body("로그인에 성공하셨습니다");
+        headers.add("Message","로그인에 성공하셨습니다.");
+        return ResponseEntity.ok().headers(headers).body(null);
     }
 
 }

--- a/src/main/java/com/backend/filb/presentation/MemberController.java
+++ b/src/main/java/com/backend/filb/presentation/MemberController.java
@@ -1,0 +1,4 @@
+package com.backend.filb.presentation;
+
+public class MemberController {
+}

--- a/src/main/java/com/backend/filb/presentation/MemberController.java
+++ b/src/main/java/com/backend/filb/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.backend.filb.presentation;
 import com.backend.filb.application.MemberService;
 import com.backend.filb.domain.entity.Member;
 import com.backend.filb.dto.MemberRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,10 +17,22 @@ public class MemberController {
     }
 
     @PostMapping("/join")
-    public ResponseEntity<Member> join(
+    public ResponseEntity<String> join(
             @RequestBody MemberRequest memberRequest
     ) {
-        Member member = memberService.join(memberRequest);
-        return ResponseEntity.ok().body(member);
+        memberService.join(memberRequest);
+        return ResponseEntity.ok().body("회원가입에 성공하셨습니다.");
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(
+            @RequestBody MemberRequest memberRequest
+    ){
+        String jwt = memberService.login(memberRequest);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", jwt);
+        return ResponseEntity.ok().headers(headers).body("로그인에 성공하셨습니다");
+    }
+
+
 }

--- a/src/main/java/com/backend/filb/presentation/MemberController.java
+++ b/src/main/java/com/backend/filb/presentation/MemberController.java
@@ -1,18 +1,20 @@
 package com.backend.filb.presentation;
 
 import com.backend.filb.application.MemberService;
-import com.backend.filb.domain.entity.Member;
 import com.backend.filb.dto.MemberRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/members")
 public class MemberController {
     private MemberService memberService;
 
-    public MemberController(MemberService memberService){
+    public MemberController(MemberService memberService) {
         this.memberService = memberService;
     }
 
@@ -27,12 +29,11 @@ public class MemberController {
     @PostMapping("/login")
     public ResponseEntity<String> login(
             @RequestBody MemberRequest memberRequest
-    ){
+    ) {
         String jwt = memberService.login(memberRequest);
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", jwt);
         return ResponseEntity.ok().headers(headers).body("로그인에 성공하셨습니다");
     }
-
 
 }

--- a/src/main/java/com/backend/filb/presentation/ReportController.java
+++ b/src/main/java/com/backend/filb/presentation/ReportController.java
@@ -1,0 +1,15 @@
+package com.backend.filb.presentation;
+
+import com.backend.filb.application.ReportService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+    private ReportService reportService;
+
+    public ReportController(ReportService reportService){
+        this.reportService = reportService;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=filb
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:test
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+token:
+  expiration: 3600


### PR DESCRIPTION
로그인이나 회원가입 성공했을 때 멤버 객체를 ResponseEntity에 넣어서 반환한다면 보안에 좋지 않은 것 같고, 로그인 성공할 때 service단에서 jwt토큰을 주어야하니까 멤버 객체를 받을 수 없어서 회원가입 할 때는 멤버를, 로그인 할 때는 성공메세지를 바디로 준다면 통일성이 떨어진다고 생각했습니다. 그래서 우선 ResponseEntity<String>으로 반환했는데 안좋다면 어케든 고쳐보겠습니다

join할 때에는 이메일정보, 닉네임 정보 등이 필요했는데 로그인 할 때는 필요가 없습니다. 그럼 이를 위한 dto를 하나 더 만드는 것이 좋은지 아니면 그냥 여기만 RequestParam을 하는 것이 좋을까 궁급합니다. 우선 있는거 걍 쓰긴 했어요

api 명세할 때 header랑 body는 받는 것 기준인지 보내는 것 기준인지 궁금합니다